### PR TITLE
Remove ADL ambiguity in `PatriciaTreeCore`.

### DIFF
--- a/include/PatriciaTreeSet.h
+++ b/include/PatriciaTreeSet.h
@@ -152,14 +152,13 @@ class PatriciaTreeSet final {
 
   PatriciaTreeSet& union_with(const PatriciaTreeSet& other) {
     // For union, empty value or empty value is empty value.
-    m_core.merge(pt_core::use_available_value<IntegerType, Empty>,
-                 other.m_core);
+    m_core.merge(pt_core::use_available_leaf<IntegerType, Empty>, other.m_core);
     return *this;
   }
 
   PatriciaTreeSet& intersection_with(const PatriciaTreeSet& other) {
     // For intersect, empty value and empty value is empty value.
-    m_core.intersect(pt_core::use_available_value<IntegerType, Empty>,
+    m_core.intersect(pt_core::use_available_leaf<IntegerType, Empty>,
                      other.m_core);
     return *this;
   }


### PR DESCRIPTION
Summary:
This happens because the free functions implementing PatriciaTreeCore accept `boost::intrusive_ptr` as arguments, so functions in the boost namespace are candidates at the callsite. It didn't occur pre-refactor because these functions took a concrete `std::function` argument that caused disambiguation. We removed the overhead of `std::function` but the result is purely templated functions.

To remove the ambiguity this ensures each of these functions contains the word "tree", "leaf", or "key" somewhere in the name, since these (currently) don't exist anywhere in boost. While we're here, also use the "_by_key" suffix consistently for functions that locate things by key.

The long-term solution would be to wrap the intrusive_ptr in some manner to disable ADL, but this is much easier.

Differential Revision: D37542177

