### PR TITLE
Add cmake_minimum_required to gtest.cmake.in

### DIFF
--- a/cmake_modules/gtest.cmake.in
+++ b/cmake_modules/gtest.cmake.in
@@ -3,6 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+cmake_minimum_required(VERSION 3.0.2)
+project("googletest")
+
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git


### PR DESCRIPTION
Recent versions of CMake (e.g. 3.24.2) appear to fail unless the `cmake_minimum_required` version is set.  Furthermore, we set `project` to silence the corresponding warning.