### PR TITLE
Add missing include for SpartaWorkQueueTest.cpp

### DIFF
--- a/test/SpartaWorkQueueTest.cpp
+++ b/test/SpartaWorkQueueTest.cpp
@@ -7,6 +7,7 @@
 
 #include "SpartaWorkQueue.h"
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <gtest/gtest.h>


### PR DESCRIPTION
SpartaWorkQueueTest.cpp only compiles with `#include <array>` using clang (macOS).