### PR TITLE
Improvements to make SPARTA easier to use as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,25 @@ install(TARGETS sparta EXPORT sparta_target
 )
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(EXPORT sparta_target DESTINATION cmake)
+install(EXPORT sparta_target
+  FILE sparta_target.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sparta"
+)
 
 # This makes the project importable from the build directory
 export(TARGETS sparta FILE sparta_target.cmake)
+
+# Generate CMake config file that can be used in other projects
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/sparta-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/sparta-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sparta"
+)
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/sparta-config.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sparta"
+)
 
 ###################################################
 # test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project("sparta")
 
 include(CTest)
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH})
 include(Commons)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ target_include_directories(sparta INTERFACE
 
 target_link_libraries(sparta INTERFACE ${Boost_LIBRARIES})
 
+add_library(sparta::sparta ALIAS sparta)
+
 ###################################################
 # install and export
 ###################################################
@@ -49,10 +51,14 @@ install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(EXPORT sparta_target
   FILE sparta_target.cmake
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sparta"
+  NAMESPACE sparta::
 )
 
 # This makes the project importable from the build directory
-export(TARGETS sparta FILE sparta_target.cmake)
+export(TARGETS sparta
+  FILE sparta_target.cmake
+  NAMESPACE sparta::
+)
 
 # Generate CMake config file that can be used in other projects
 include(CMakePackageConfigHelpers)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,35 @@ To copy the header files into `/usr/local/include/sparta` and set up a cmake lib
 sudo make install
 ```
 
+### CMake Setup
+
+If you are using CMake for your project, you can also use SPARTA in the following ways:
+
+* A system-wide installation of SPARTA will contain a CMake configuration file that exports the library as `sparta::sparta`. This enables the use of `find_package` to locate SPARTA. For example:
+
+  ```cmake
+  find_package(Boost REQUIRED COMPONENTS thread) # required by SPARTA
+  find_package(sparta REQUIRED)
+  add_library(MyAnalysisLibrary)
+  target_link_libraries(MyAnalysisLibrary PUBLIC sparta::sparta)
+  ```
+
+* If you have cloned and "built" SPARTA locally, you can use a `find_package` call (such as the one above) and run CMake with the `-Dsparta_DIR=<your_sparta_build_dir>` to load the library:
+
+  ```sh
+  # Assuming you are at the top-level of your project that uses SPARTA
+  mkdir build && cd build
+  cmake .. -Dsparta_DIR=path/to/your/sparta/build
+  ```
+
+* SPARTA can be added as a subdirectory in your project:
+
+  ```cmake
+  # assuming you have cloned SPARTA into a folder named sparta
+  add_subdirectory(sparta)
+  add_library(MyAnalysisLibrary)
+  target_link_libraries(MyAnalysisLibrary PUBLIC sparta::sparta)
+  ```
 
 ## Issues
 

--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -44,14 +44,14 @@ macro(add_dependent_packages_for_sparta)
   configure_file(cmake_modules/gtest.cmake.in googletest-download/CMakeLists.txt)
   execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
     RESULT_VARIABLE result
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download
   )
   if(result)
     message(FATAL_ERROR "CMake step for googletest failed: ${result}")
   endif()
   execute_process(COMMAND ${CMAKE_COMMAND} --build .
     RESULT_VARIABLE result
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download
   )
   if(result)
     message(FATAL_ERROR "Build step for googletest failed: ${result}")
@@ -64,8 +64,8 @@ macro(add_dependent_packages_for_sparta)
   # Add googletest directly to our build. This defines
   # the gtest and gtest_main targets.
   add_subdirectory(
-    ${CMAKE_BINARY_DIR}/googletest-src
-    ${CMAKE_BINARY_DIR}/googletest-build
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
     EXCLUDE_FROM_ALL
   )
 

--- a/cmake_modules/gtest.cmake.in
+++ b/cmake_modules/gtest.cmake.in
@@ -10,8 +10,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           release-1.8.1
-  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/cmake_modules/sparta-config.cmake.in
+++ b/cmake_modules/sparta-config.cmake.in
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Boost COMPONENTS thread)
+
+include("${CMAKE_CURRENT_LIST_DIR}/sparta_target.cmake")


### PR DESCRIPTION
This PR includes some improvements to the CMake configuration that makes SPARTA easier to use as a dependency (or at least I've found these useful for a project I'm working on). Specifically:

* Generate a `sparta-config.cmake` file that is created in both the build folder and for the install target. This enables the library to be used with `find_package`.
* (Breaking change) Install the `sparta_target.cmake` to `$LIBDIR/cmake/sparta` instead of `$PREFIX/cmake` to support \*nix systems as well as `find_package`. While this is a breaking change, it's unlikely that anyone used the installed file due to the bugs observed in #23.
* (Breaking change) Use `sparta::` as the target namespace when exporting the `sparta` target. Projects that previously included the `sparta_target.cmake` will need to be updated to use  `sparta::sparta` instead of `sparta` when specifying it as a dependency.
* Update the README with additional tips on how to use SPARTA in CMake projects.

This PR is stacked on top of #23, and I'll rebase after it is merged.