### PR TITLE
Bump GoogleTest to v1.13.0

### DIFF
--- a/cmake_modules/gtest.cmake.in
+++ b/cmake_modules/gtest.cmake.in
@@ -9,7 +9,7 @@ project("googletest")
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.8.1
+  GIT_TAG           v1.13.0
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Summary:
GitHub build is failing in main because GoogleTest v1.8.0 doesn't support REGISTER_TYPED_TEST_SUITE_P.

Not bumping to v1.17 to be safe because v1.14.0+ requires C++14.

Differential Revision: D76534898
