### PR TITLE
Reuse the existing leaf when inserting an equal binding

### DIFF
--- a/rust/src/datatype/patricia_tree_impl.rs
+++ b/rust/src/datatype/patricia_tree_impl.rs
@@ -661,12 +661,28 @@ impl<V> PatriciaTree<V> {
         self.root = op(temp_root);
     }
 
-    pub(crate) fn insert(&mut self, key: BitVec, value: V) {
-        let new_leaf = Rc::new(Node::Leaf {
-            key: key.clone(),
-            value,
-        });
-        let node_op = move |_| Some(new_leaf);
+    pub(crate) fn insert(&mut self, key: BitVec, value: V)
+    where
+        V: Eq,
+    {
+        let leaf_key = key.clone();
+        let node_op = move |existing: Option<Rc<Node<V>>>| {
+            let value_is_unchanged = matches!(
+                existing.as_deref(),
+                Some(Node::Leaf { value: old_value, .. }) if *old_value == value
+            );
+
+            if value_is_unchanged {
+                // Keep the existing leaf, so that the branches above it are
+                // shared rather than rebuilt.
+                existing
+            } else {
+                Some(Rc::new(Node::Leaf {
+                    key: leaf_key,
+                    value,
+                }))
+            }
+        };
         let root_op = move |root| Node::update_node_by_key(root, &key, node_op);
         self.apply_root_operation(root_op);
     }
@@ -926,6 +942,33 @@ mod tests {
         let mut united = tree.clone();
         united.union_with(&set_of(0..100), |_, _| ());
         assert_eq!(root_ptr(&united), root);
+
+        let mut inserted = tree.clone();
+        inserted.insert(500u32.into(), ());
+        assert_eq!(root_ptr(&inserted), root);
+    }
+
+    /// Re-inserting an equal binding must be free, but a different value must
+    /// still take effect and must not disturb trees sharing the old one.
+    #[test]
+    fn test_insert_of_existing_binding_preserves_sharing() {
+        let mut tree: PatriciaTree<u32> = PatriciaTree::new();
+        for i in 0u32..1000 {
+            tree.insert(i.into(), i * 2);
+        }
+        let root = root_ptr(&tree);
+
+        let mut same = tree.clone();
+        same.insert(500u32.into(), 1000);
+        assert_eq!(root_ptr(&same), root);
+        assert_eq!(same.get(&500u32.into()), Some(&1000));
+
+        let mut changed = tree.clone();
+        changed.insert(500u32.into(), 7);
+        assert_ne!(root_ptr(&changed), root);
+        assert_eq!(changed.len(), 1000);
+        assert_eq!(changed.get(&500u32.into()), Some(&7));
+        assert_eq!(tree.get(&500u32.into()), Some(&1000));
     }
 
     /// The leaf reuse above must not swallow an actual change of value.

--- a/rust/src/datatype/patricia_tree_map.rs
+++ b/rust/src/datatype/patricia_tree_map.rs
@@ -42,7 +42,10 @@ impl<K: Into<BitVec>, V> PatriciaTreeMap<K, V> {
         self.storage.len()
     }
 
-    pub fn upsert(&mut self, key: K, value: V) {
+    pub fn upsert(&mut self, key: K, value: V)
+    where
+        V: Eq,
+    {
         self.storage.insert(key.into(), value)
     }
 
@@ -114,7 +117,7 @@ impl<'a, K: 'a + Into<BitVec> + From<&'a BitVec>, V> Iterator
     }
 }
 
-impl<K: Into<BitVec>, V> FromIterator<(K, V)> for PatriciaTreeMap<K, V> {
+impl<K: Into<BitVec>, V: Eq> FromIterator<(K, V)> for PatriciaTreeMap<K, V> {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let mut ret: PatriciaTreeMap<K, V> = PatriciaTreeMap::new();
         for (k, v) in iter {


### PR DESCRIPTION
`insert` built its replacement leaf before looking at the tree, so re-inserting a binding that is already present allocated a new leaf and, because that leaf was not pointer-equal to the old one, rebuilt every branch from the root down to it. The tree it produced was equal to the one it started from but shared nothing with it, which also cost the `Rc::ptr_eq` fast paths on every later operation against the original.

Build the leaf only when it is actually needed: if the key is already bound to an equal value, hand the existing leaf back so that the checks added to `update_node_by_key` recognise the subtree as unchanged and share it. This is what the C++ implementation does in `update_leaf_internal` (PatriciaTreeCore.h).

Comparing against the stored value requires `V: Eq`. Unlike the previous change this does reach the public API: `PatriciaTreeMap::upsert` and the `FromIterator` impl for `PatriciaTreeMap` now carry the bound. `PatriciaTreeMap` already required `V: Eq` for its own `PartialEq`, and `PatriciaTreeSet` is unaffected (its value type is `()`), so in practice nothing that compiled before stops compiling. C++ has the same requirement through `Value::equals` in its `Value` contract.

One behavioural note: when the values compare equal, the previously stored value is now kept rather than replaced by the newly supplied one. For a correct `Eq` the two are interchangeable. The same is true of the C++ implementation.

Measured with a counting global allocator, re-inserting an existing key into a 10,000 element `PatriciaTreeSet<u32>` goes from 14 allocations to 0. Together with the previous change, all of remove-absent-key, insert-existing-key, intersect-with-superset and union-with-subset now allocate nothing.

Test plan: `cargo test` — 56 tests pass, including a new one covering both that re-inserting an equal binding keeps the root pointer and that inserting a different value still takes effect without disturbing trees sharing the old one. `cargo clippy --all-targets` emits the same warnings as the parent branch, and `cargo fmt --check` reports no diff for either file.